### PR TITLE
fix e2e

### DIFF
--- a/pkg/reconciler/pendingpipelinerun/metrics.go
+++ b/pkg/reconciler/pendingpipelinerun/metrics.go
@@ -2,6 +2,7 @@ package pendingpipelinerun
 
 import (
 	"context"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -75,7 +76,13 @@ func (sc *statsCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (sc *statsCollector) Collect(ch chan<- prometheus.Metric) {
-	cts, err := PipelineRunStats(context.Background(), sc.client, metav1.NamespaceAll)
+	prList := v1beta1.PipelineRunList{}
+	opts := &client.ListOptions{Namespace: metav1.NamespaceAll}
+	if err := sc.client.List(context.Background(), &prList, opts); err != nil {
+		//TODO add log / event
+		return
+	}
+	cts, err := PipelineRunStats(&prList)
 	if err != nil {
 		//TODO add log / event
 		return


### PR DESCRIPTION
```
=== RUN   TestServiceRegistry/maintain_pipelinerun_quota
=== CONT  TestServiceRegistry
    types.go:25: time: 2022-12-12 16:41:11.917042445 -0500 EST m=+318.784755529: we have 0 active pipeline runs
    types.go:25: time: 2022-12-12 16:42:12.336222972 -0500 EST m=+379.203936056: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:43:12.6174326 -0500 EST m=+439.485145684: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:44:12.517854149 -0500 EST m=+499.385567231: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:45:12.795075029 -0500 EST m=+559.662788113: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:46:12.73347444 -0500 EST m=+619.601187533: we have 45 active pipeline runs
    types.go:25: time: 2022-12-12 16:47:13.139138567 -0500 EST m=+680.006851650: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:48:12.765368014 -0500 EST m=+739.633081099: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:49:12.799614677 -0500 EST m=+799.667327760: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:50:12.949393894 -0500 EST m=+859.817106976: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:51:12.831584423 -0500 EST m=+919.699297506: we have 45 active pipeline runs
    types.go:25: time: 2022-12-12 16:52:13.166241385 -0500 EST m=+980.033954472: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:53:12.953548602 -0500 EST m=+1039.821261684: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:54:13.007254964 -0500 EST m=+1099.874968046: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:55:13.18452634 -0500 EST m=+1160.052239422: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:56:12.980552999 -0500 EST m=+1219.848266095: we have 46 active pipeline runs
    types.go:25: time: 2022-12-12 16:56:13.911329264 -0500 EST m=+1220.779042348: we have 46 active pipeline runs
--- PASS: TestServiceRegistry (1220.76s)
    --- PASS: TestServiceRegistry/pipelinerun_completes_successfully (315.28s)
    --- PASS: TestServiceRegistry/maintain_pipelinerun_quota (902.09s)
PASS
ok  	github.com/gabemontero/pipelinerun-rate-limiter/openshift-with-appstudio-test/e2e	1220.785s
gmontero ~/go/src/github.com/gabemontero/pipelinerun-rate-limiter  (fix-e2e)$ 
```